### PR TITLE
Fix for millis() roll over problem.

### DIFF
--- a/Arduino_Task_Scheduler/Task.cpp
+++ b/Arduino_Task_Scheduler/Task.cpp
@@ -12,5 +12,46 @@ bool TriggeredTask::canRun(uint32_t now) {
 
 // Virtual.
 bool TimedTask::canRun(uint32_t now) {
-    return now >= runTime;
+    /*
+     * If millis() and runTime have not rolled over
+     * then return now >= runTime. (As previously.)
+     */
+
+    /*
+     * Has anything rolled over?
+     */
+    bool millisRollOver = (now < lastRunTime);
+    bool runTimeRollover = (runTime < lastRunTime);
+
+    /* 
+     *  Assume no rollovers, most common scenario. If
+     *  we are about to run a task, log its last run time.
+     *  If both rolled over, we stay here too.
+     */    
+    if ((!millisRollOver && !runTimeRollover) ||
+        (millisRollOver && runTimeRollover)) {
+        if (now >= runTime) {
+            lastRunTime = now;
+            return true;
+        }
+    }
+
+    // If runTime rolled over then we must wait for millis
+    // to roll over as well. So as long as `millis()` is > than
+    // next run, we return false;
+    if (runTimeRollover) {
+        if (now > runTime) {
+            return false;
+        }
+
+        // Otherwise log the last run time
+        // and return true.
+        lastRunTime = now;
+        return true;
+    }
+
+    // Anything else is false. `millis()` can't rollover and
+    // runTime not. Only the other way around as dealt with
+    // above.
+    return false;    
 }

--- a/Arduino_Task_Scheduler/Task.h
+++ b/Arduino_Task_Scheduler/Task.h
@@ -105,6 +105,7 @@ public:
 protected:
     
     uint32_t runTime;   // The  system clock tick when the task can next run.
+    uint32_t lastRunTime;   // The  system clock tick when the task last ran.
 };
 
 #endif


### PR DESCRIPTION
Good Afternoon Kevin,

as promised on the comments on your blog at https://www.hackster.io/GadgetsToGrow/don-t-delay-use-an-arduino-task-scheduler-today-215cfe, here's the pull request that fixes, I think, the problem whereby `millis()` will roll over every 49 days, 17 hours and a bit.

I've tested this with the original demo and all appears well.

Cheers,
Norm. 