### PR TITLE
Another fix for mills() overflow issue

### DIFF
--- a/Arduino_Task_Scheduler/Arduino_Task_Scheduler.ino
+++ b/Arduino_Task_Scheduler/Arduino_Task_Scheduler.ino
@@ -188,7 +188,7 @@ private:
 // *** Blinker Constructor
 // ***
 Blinker::Blinker(uint8_t _pin, uint32_t _rate, Debugger *_ptrDebugger)
-	: TimedTask(millis()),
+	: TimedTask(millis(), RATE_BLINKER_BLINK),
 	pin(_pin),
 	rate(_rate),
 	on(false),
@@ -215,7 +215,7 @@ void Blinker::run(uint32_t now)
 		ptrDebugger->debugWrite("BLINKER: ON");
 	}
 	// Run again in the specified number of milliseconds.
-	incRunTime(rate);
+	setIntervalTime(rate);
 }
 
 /*****************************************************************************************
@@ -251,7 +251,7 @@ private:
 // *** Fader Constructor
 // ***
 Fader::Fader(uint8_t _pin, uint8_t _increment, uint32_t _rate, Debugger *_ptrDebugger)
-	: TimedTask(millis()),
+	: TimedTask(millis(), RATE_FADER_FADE),
 	pin(_pin),
 	increment(_increment),
 	rate(_rate),
@@ -291,7 +291,7 @@ void Fader::run(uint32_t now)
 	}
 	
 	// Run again in the specified number of milliseconds.
-	incRunTime(rate);
+	setIntervalTime(rate);
 }
 
 /****************************************************************************************
@@ -408,7 +408,7 @@ private:
 // *** Note the passing of the _ptrAlarm to allow access to setAlarmCondition() and setRunnable()
 // ***
 PhotocellSensor::PhotocellSensor(uint8_t _pin, uint32_t _rate, LightLevelAlarm *_ptrAlarm, Debugger *_ptrDebugger)
-: TimedTask(millis()),
+: TimedTask(millis(), RATE_PHOTOCELL_READING),
 pin(_pin),
 rate(_rate),
 lightLevel(0),
@@ -457,7 +457,7 @@ void PhotocellSensor::run(uint32_t now)
 	ptrAlarm->setRunnable();
 	
 	// Run again in the specified number of milliseconds.
-	incRunTime(rate);
+	setIntervalTime(rate);
 }
 
 /**************************************************************************************

--- a/Arduino_Task_Scheduler/Task.cpp
+++ b/Arduino_Task_Scheduler/Task.cpp
@@ -12,5 +12,9 @@ bool TriggeredTask::canRun(uint32_t now) {
 
 // Virtual.
 bool TimedTask::canRun(uint32_t now) {
-    return now >= runTime;
+    if (now - runTime > intervalTime) {
+        runTime = now;
+        return true;
+    }
+    else return false;
 }

--- a/Arduino_Task_Scheduler/Task.h
+++ b/Arduino_Task_Scheduler/Task.h
@@ -76,7 +76,7 @@ public:
      * Create a periodically executed task.
      * when - the system clock tick when the task should run, in milliseconds.
      */
-    inline TimedTask(uint32_t when) { runTime = when; }
+    inline TimedTask(uint32_t when, uint32_t interval) { runTime = when; intervalTime = interval;}
 
     /*
      * Can the task currently run?
@@ -91,10 +91,10 @@ public:
     inline void setRunTime(uint32_t when) { runTime = when; }
 
     /*
-     * Increment the system clock tick when the task can next run.
-     * inc - system clock increment, in milliseconds.
+     * set the system clock tick interval where the task should run at each interval.
+     * interval - system clock increment, in milliseconds.
      */
-    inline void incRunTime(uint32_t inc) { runTime += inc; }
+    inline void setIntervalTime(uint32_t interval) { intervalTime = interval; }
 
     /*
      * Get the system clock tick when the task can next run.
@@ -104,7 +104,8 @@ public:
 
 protected:
     
-    uint32_t runTime;   // The  system clock tick when the task can next run.
+    uint32_t runTime;   // The previous system clock tick.
+    uint32_t intervalTime; // The interval of system clock tick to decide task can next run.
 };
 
 #endif


### PR DESCRIPTION
    Current implementation of TimedTask::canRun is continously adding inc time to
    to runTime, then compare "now > runTime" to decide timed task is runnable.
    The problem with this implementation is runTime variable will get overflow.
    
    In this commit, for timed task, a interval time between task is set instead,
    it will check the condition "(now - runTime) >= intervalTime" to decide task
    is runnable.
    
    how does this solve the overflow issue:
    let says intervalTime is 60000 and "now" is near overflow
    now         -  runTime      =  difference
    4294917296     4294917296               0  <-- we start timing here
    4294917297     4294917296               1
    4294917298     4294917296               2
    ...
    4294967295     4294917296           49999  <-- largest unsigned long value
             0     4294917296           50000  <-- wraps here back to zero
             1     4294917296           50001  <-- keeps counting up
    ...
          9999     4294917296           59999
         10000     4294917296           60000  <-- time's up!
    
    the number says it all.
    the details explaination can be found here:
    https://www.gammon.com.au/millis